### PR TITLE
allow resource metadata to be explicitly set in config file

### DIFF
--- a/deploy-config-example.js
+++ b/deploy-config-example.js
@@ -71,6 +71,9 @@ var config = {
       credentials: s3Credential,
       dirname: '/development/assets',
       assetsPath: 'dist/assets/*',
+      headers: {
+        'Cache-Control': 'max-age=0' // explicitly set metadata for resource in S3
+      }
     },
     staging: {
       credentials: s3Credential,
@@ -128,4 +131,3 @@ var config = {
 };
 
 module.exports = config;
-

--- a/tasks/deploy-s3.js
+++ b/tasks/deploy-s3.js
@@ -27,7 +27,8 @@ var deployS3 = function(config) {
   var publisher = aws.create(config.credentials);
 
   // define custom headers
-  var headers = { 'Cache-Control': 'max-age=315360000, no-transform, public' };
+
+  var headers = config.headers? config.headers : { 'Cache-Control': 'max-age=315360000, no-transform, public' };
 
   return gulp.src(config.assetsPath)
     .pipe(rename(function (filepath) {


### PR DESCRIPTION
We needed to set max-age=0 to prevent Cloudfront from caching in dev/stage.

This simple change allows the default headers to be set in the config file.

Sorry, haven't had time to create any tests.