### PR TITLE
always use commit sha for rollbar revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Gulp is great for building, Bash for running tasks.
 - abstract slack notifs into utils
 - disallow activation of feature branches?
 - get rid of the callback hell
+- deploy tags don't work well with feature branches, they keep overwriting
 
 ## License
 MIT

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -80,7 +80,7 @@ fi
 
 gulp_config deploy-s3 --env=$ENV
 
-gulp_config rollbar-source-map --env=$ENV --rev=$REV
+gulp_config rollbar-source-map --env=$ENV --rev=$COMMIT
 
 gulp_config deploy-redis --env=$ENV --rev=$REV
 


### PR DESCRIPTION
Using Git SHA is a better option than feature branches since there could be multiple branches with the same SHA.