### PR TITLE
add rollbar hash length config option

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -54,8 +54,8 @@ case "$ENV" in
   exit 1
 esac
 
-ABBREV_LENGTH=`node ${DIRNAME}/../tasks/config-abbrev`
-ROLLBAR_ABBREV=`node ${DIRNAME}/../tasks/config-rollbar-abbrev`
+ABBREV_LENGTH=`node ${DIRNAME}/../tasks/config-abbrev --env=$ENV`
+ROLLBAR_ABBREV=`node ${DIRNAME}/../tasks/config-rollbar-abbrev --env=$ENV`
 COMMIT=`git rev-parse --short=${ABBREV_LENGTH} HEAD`
 COMMIT_ROLLBAR=`git rev-parse --short=${ROLLBAR_ABBREV} HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD`

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -55,7 +55,9 @@ case "$ENV" in
 esac
 
 ABBREV_LENGTH=`node ${DIRNAME}/../tasks/config-abbrev`
+ROLLBAR_ABBREV=`node ${DIRNAME}/../tasks/config-rollbar-abbrev`
 COMMIT=`git rev-parse --short=${ABBREV_LENGTH} HEAD`
+COMMIT_ROLLBAR=`git rev-parse --short=${ROLLBAR_ABBREV} HEAD`
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 REV="$COMMIT"
 BUILD_COUNT=`ls -a build*log 2>/dev/null | cat | wc -l | awk {'print $1'}`
@@ -81,7 +83,7 @@ fi
 
 gulp_config deploy-s3 --env=$ENV
 
-gulp_config rollbar-source-map --env=$ENV --rev=$COMMIT
+gulp_config rollbar-source-map --env=$ENV --rev=$COMMIT_ROLLBAR
 
 gulp_config deploy-redis --env=$ENV --rev=$REV
 

--- a/deploy-config-example.js
+++ b/deploy-config-example.js
@@ -94,16 +94,19 @@ var config = {
       minifiedUrl: 'http://cdn.example.com/assets/main-%s.js',
       sourceMapPath: 'dist/assets/main-%s.map',
       accessToken: secrets.rollbar.development.accessToken,
+      abbrev: 7,
     },
     staging: {
       minifiedUrl: 'http://cdn.example.com/assets/main-%s.js',
       sourceMapPath: 'dist/assets/main-%s.map',
       accessToken: secrets.rollbar.staging.accessToken,
+      abbrev: 7,
     },
     production: {
       minifiedUrl: 'http://cdn.example.com/assets/main-%s.js',
       sourceMapPath: 'dist/assets/main-%s.map',
       accessToken: secrets.rollbar.production.accessToken,
+      abbrev: 7,
     }
   },
 

--- a/deploy-config-example.js
+++ b/deploy-config-example.js
@@ -122,10 +122,10 @@ var config = {
   },
 
   git: {
-    abbrev: 7,
     staging: {
       url: 'https://staging.example.com',
       remote: 'origin',
+      abbrev: 7,
     }
   },
 

--- a/tasks/config-rollbar-abbrev
+++ b/tasks/config-rollbar-abbrev
@@ -4,7 +4,7 @@ var DEFAULT_CONFIG_ABBREV = 7;
 var path = require('path');
 var getConfigFor = require('../tasks/utils').getConfigFor;
 
-var config = getConfigFor('git', true);
+var config = getConfigFor('rollbar', true);
 var abbrev = (config && config.abbrev) || DEFAULT_CONFIG_ABBREV;
 
 process.stdout.write(abbrev.toString());


### PR DESCRIPTION
Adds an option to specify the length of Rollbar source map hash.
Also fixes an issue we've introduced in the recent Git SHA update.