### PR TITLE
Improved `rollbar-source-map` task to support code-splitting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 
 # ide, editors
 *.sublime-workspace
+.idea


### PR DESCRIPTION
Now allowing to use regex in `sourceMapPath` to match multiple files.