### PR TITLE
RFC: Call gulp with npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Git tag creation and push to remote.
 ### Why Bash with Gulp?
 Gulp is great for building, Bash for running tasks.
 
+### NPM >= 5.2.0 required
+To find gulp binary also in mono-repos, `npx` is used. `npx` is included with npm from version 5.2.0.
+
 ## TODO
 - reupload/rewrite source map upload to fix activation of feature branches
 - build sample app in monolithic repo

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,13 +5,7 @@ trap 'exit' ERR
 # let echo interpret escape chars (\n)
 shopt -s xpg_echo
 
-GULP="`npm bin`/gulp"
-
-if [[ ! -x "$GULP" ]]; then
-  echo "ERROR: gulp executable not found"
-  echo "Check path for valid executable: $GULP"
-  exit 1
-fi
+GULP="npx gulp"
 
 gulp_config() {
   $GULP --gulpfile "$DIRNAME/../gulpfile.js" --cwd=$PWD $@

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "deploy": "npm run s3 & npm run redis & wait",
     "lint": "./node_modules/.bin/eslint --config .eslintrc.json tasks"
   },
+  "engines": {
+    "npm": ">= 5.2.0"
+  },
   "dependencies": {
     "async": "^1.4.2",
     "autoprefixer-core": "^5.2.1",


### PR DESCRIPTION
This will find gulp in mono-repo!
This package has `gulp` in dependencies so it creates a binary in the main `node_modules/.bin`
Problem in mono-repo was that `webpack-deploy` got installed to specific app's `note_modules` and `gulp` to the main/root `node_modules` so it couldn't have been called easily. This was solved by listing `gulp` as direct dependency, but that's not a good solution.

This solves it I think, because `npx` can find it recursively. Didn't want to use `yarn`, because then we would need to make that a requirement to use `webpack-deploy`. So now it's rather dependant on `npm >= 5.2.0` because that's when `npx` got first bundled with `npm`