### PR TITLE
Add under @productboard scope

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 productboard, Inc. <oss@productboard.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,3 @@
+# Maintainers
+
+[@matejlauko](github.com/matejlauko)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webpack-deploy",
+  "name": "@productboard/webpack-deploy",
   "version": "0.13.1",
   "description": "Collection of useful utilities for deploying (not only) Webpack apps",
   "main": "index.js",


### PR DESCRIPTION
Adds webpack-deploy under <img width="36" height="36" src="https://lh3.googleusercontent.com/dclCO7eoGg-Zy7mLULeK9_v84h-uLzQNj1snHMcq1k14y8HUK487e75geTv10PM0ssqgKSUq2Q=w128-h128-e365" /> organization / scope on npm!

https://www.npmjs.com/package/@productboard/webpack-deploy