### PR TITLE
fix: fallback to CI branch env

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -58,7 +58,7 @@ ABBREV_LENGTH=`node ${DIRNAME}/../tasks/config-abbrev --env=$ENV`
 ROLLBAR_ABBREV=`node ${DIRNAME}/../tasks/config-rollbar-abbrev --env=$ENV`
 COMMIT=`git rev-parse --short=${ABBREV_LENGTH} HEAD`
 COMMIT_ROLLBAR=`git rev-parse --short=${ROLLBAR_ABBREV} HEAD`
-BRANCH=`git rev-parse --abbrev-ref HEAD`
+BRANCH="${CI_COMMIT_REF_NAME:-`git rev-parse --abbrev-ref HEAD`}"
 REV="$COMMIT"
 BUILD_COUNT=`ls -a build*log 2>/dev/null | cat | wc -l | awk {'print $1'}`
 


### PR DESCRIPTION
Let's use CI's env with branch name in case it exits.